### PR TITLE
Add lists to display values not shown in pies

### DIFF
--- a/dashboards/reps_activities.json
+++ b/dashboards/reps_activities.json
@@ -8,12 +8,12 @@
                 "searchSourceJSON": "{\"filter\":[{\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}}}]}"
             },
             "optionsJSON": "{\"darkTheme\":false}",
-            "panelsJSON": "[{\"col\":9,\"id\":\"remo_activities_categories\",\"panelIndex\":10,\"row\":1,\"size_x\":2,\"size_y\":2,\"title\":\"Categories\",\"type\":\"visualization\"},{\"col\":4,\"id\":\"remo_activities\",\"panelIndex\":12,\"row\":1,\"size_x\":3,\"size_y\":2,\"title\":\"Reports\",\"type\":\"visualization\"},{\"col\":1,\"id\":\"remo_activities_main_numbers\",\"panelIndex\":13,\"row\":1,\"size_x\":3,\"size_y\":2,\"title\":\"Summary\",\"type\":\"visualization\"},{\"col\":7,\"id\":\"remo_activities_typeof\",\"panelIndex\":14,\"row\":1,\"size_x\":2,\"size_y\":2,\"title\":\"Activity\",\"type\":\"visualization\"},{\"col\":1,\"id\":\"remo_activities_map\",\"panelIndex\":16,\"row\":3,\"size_x\":6,\"size_y\":5,\"title\":\"Reports\",\"type\":\"visualization\"},{\"col\":11,\"id\":\"remo_activities_initiatives\",\"panelIndex\":17,\"row\":1,\"size_x\":2,\"size_y\":2,\"title\":\"Initiatives\",\"type\":\"visualization\"},{\"col\":7,\"id\":\"remo_activities_authors\",\"panelIndex\":18,\"row\":3,\"size_x\":3,\"size_y\":5,\"title\":\"Report Authors\",\"type\":\"visualization\"},{\"col\":10,\"id\":\"remo_activities_mentors\",\"panelIndex\":19,\"row\":3,\"size_x\":3,\"size_y\":5,\"title\":\"Mentors\",\"type\":\"visualization\"},{\"col\":1,\"columns\":[\"activity\",\"activity_description\",\"functional_areas\",\"author_name\",\"mentor\",\"report_date\",\"location\",\"remo_url\",\"link\"],\"id\":\"remo-activities-Search:_author_mentor_activity_date_url_location\",\"panelIndex\":20,\"row\":8,\"size_x\":12,\"size_y\":5,\"sort\":[\"report_date\",\"desc\"],\"title\":\"Last Report\",\"type\":\"search\"}]",
+            "panelsJSON": "[{\"col\":9,\"id\":\"remo_activities_categories\",\"panelIndex\":10,\"row\":1,\"size_x\":2,\"size_y\":2,\"title\":\"Categories\",\"type\":\"visualization\"},{\"col\":4,\"id\":\"remo_activities\",\"panelIndex\":12,\"row\":1,\"size_x\":3,\"size_y\":2,\"title\":\"Reports\",\"type\":\"visualization\"},{\"col\":1,\"id\":\"remo_activities_main_numbers\",\"panelIndex\":13,\"row\":1,\"size_x\":3,\"size_y\":2,\"title\":\"Summary\",\"type\":\"visualization\"},{\"col\":7,\"id\":\"remo_activities_typeof\",\"panelIndex\":14,\"row\":1,\"size_x\":2,\"size_y\":2,\"title\":\"Activity\",\"type\":\"visualization\"},{\"col\":1,\"id\":\"remo_activities_map\",\"panelIndex\":16,\"row\":3,\"size_x\":6,\"size_y\":5,\"title\":\"Reports\",\"type\":\"visualization\"},{\"col\":11,\"id\":\"remo_activities_initiatives\",\"panelIndex\":17,\"row\":1,\"size_x\":2,\"size_y\":2,\"title\":\"Initiatives\",\"type\":\"visualization\"},{\"col\":7,\"id\":\"remo_activities_authors\",\"panelIndex\":18,\"row\":3,\"size_x\":3,\"size_y\":5,\"title\":\"Report Authors\",\"type\":\"visualization\"},{\"col\":10,\"id\":\"remo_activities_mentors\",\"panelIndex\":19,\"row\":3,\"size_x\":3,\"size_y\":5,\"title\":\"Mentors\",\"type\":\"visualization\"},{\"col\":1,\"columns\":[\"activity\",\"activity_description\",\"functional_areas\",\"author_name\",\"mentor\",\"report_date\",\"location\",\"remo_url\",\"link\"],\"id\":\"remo-activities-Search:_author_mentor_activity_date_url_location\",\"panelIndex\":20,\"row\":8,\"size_x\":12,\"size_y\":5,\"sort\":[\"report_date\",\"desc\"],\"title\":\"Last Reports\",\"type\":\"search\"},{\"col\":5,\"id\":\"remo_activities_categories_list\",\"panelIndex\":21,\"row\":13,\"size_x\":4,\"size_y\":5,\"title\":\"Categories\",\"type\":\"visualization\"},{\"col\":1,\"id\":\"remo_activities_typeof_list\",\"panelIndex\":22,\"row\":13,\"size_x\":4,\"size_y\":5,\"title\":\"Activities\",\"type\":\"visualization\"},{\"id\":\"remo_activities_initiatives_list\",\"type\":\"visualization\",\"panelIndex\":23,\"size_x\":4,\"size_y\":5,\"col\":9,\"row\":13,\"title\":\"Initiatives\"}]",
             "timeFrom": "now-2y",
             "timeRestore": true,
             "timeTo": "now",
             "title": "Reps Activities",
-            "uiStateJSON": "{\"P-10\":{\"title\":\"Categories\",\"vis\":{\"legendOpen\":true}},\"P-12\":{\"title\":\"Reports\",\"vis\":{\"legendOpen\":false}},\"P-13\":{\"title\":\"Summary\"},\"P-14\":{\"title\":\"Activity\"},\"P-16\":{\"title\":\"Reports\"},\"P-17\":{\"title\":\"Initiatives\"},\"P-18\":{\"title\":\"Report Authors\"},\"P-19\":{\"title\":\"Mentors\"},\"P-20\":{\"title\":\"Last Report\"}}",
+            "uiStateJSON": "{\"P-10\":{\"title\":\"Categories\",\"vis\":{\"legendOpen\":true}},\"P-12\":{\"title\":\"Reports\",\"vis\":{\"legendOpen\":false}},\"P-13\":{\"title\":\"Summary\"},\"P-14\":{\"title\":\"Activity\"},\"P-16\":{\"title\":\"Reports\"},\"P-17\":{\"title\":\"Initiatives\"},\"P-18\":{\"title\":\"Report Authors\"},\"P-19\":{\"title\":\"Mentors\"},\"P-20\":{\"title\":\"Last Reports\"},\"P-21\":{\"title\":\"Categories\"},\"P-22\":{\"title\":\"Activities\"},\"P-23\":{\"title\":\"Initiatives\"}}",
             "version": 1
         }
     },
@@ -160,6 +160,45 @@
                 "uiStateJSON": "{}",
                 "version": 1,
                 "visState": "{\"title\":\"remo_activities_mentors\",\"type\":\"table\",\"params\":{\"perPage\":10,\"showPartialRows\":false,\"showMeticsAtAllLevels\":false},\"aggs\":[{\"id\":\"1\",\"type\":\"count\",\"schema\":\"metric\",\"params\":{\"customLabel\":\"Activities\"}},{\"id\":\"2\",\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"mentor\",\"size\":50,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"Mentor\"}},{\"id\":\"3\",\"type\":\"cardinality\",\"schema\":\"metric\",\"params\":{\"field\":\"author_name\",\"customLabel\":\"Mentored People\"}},{\"id\":\"4\",\"type\":\"cardinality\",\"schema\":\"metric\",\"params\":{\"field\":\"initiative\",\"customLabel\":\"Initiatives\"}},{\"id\":\"5\",\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"mentor_profile_url\",\"size\":1,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"URL\"}},{\"id\":\"6\",\"type\":\"cardinality\",\"schema\":\"metric\",\"params\":{\"field\":\"functional_areas.name\",\"customLabel\":\"Categories\"}}],\"listeners\":{}}"
+            }
+        },
+        {
+            "id": "remo_activities_categories_list",
+            "value": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": "{\"index\":\"remo-activities\",\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"filter\":[]}"
+                },
+                "title": "remo_activities_categories_list",
+                "uiStateJSON": "{}",
+                "version": 1,
+                "visState": "{\"title\":\"remo_activities_categories_list\",\"type\":\"table\",\"params\":{\"perPage\":10,\"showPartialRows\":false,\"showMeticsAtAllLevels\":false},\"aggs\":[{\"id\":\"3\",\"type\":\"cardinality\",\"schema\":\"metric\",\"params\":{\"field\":\"author_uuid\",\"customLabel\":\"People\"}},{\"id\":\"1\",\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"functional_areas.name\",\"size\":500,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"Category\"}}],\"listeners\":{}}"
+            }
+        },
+        {
+            "id": "remo_activities_typeof_list",
+            "value": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": "{\"index\":\"remo-activities\",\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"filter\":[]}"
+                },
+                "title": "remo_activities_typeof_list",
+                "uiStateJSON": "{}",
+                "version": 1,
+                "visState": "{\"title\":\"remo_activities_typeof_list\",\"type\":\"table\",\"params\":{\"perPage\":10,\"showPartialRows\":false,\"showMeticsAtAllLevels\":false},\"aggs\":[{\"id\":\"3\",\"type\":\"cardinality\",\"schema\":\"metric\",\"params\":{\"field\":\"author_uuid\",\"customLabel\":\"People\"}},{\"id\":\"1\",\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"activity\",\"size\":500,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"Activity\"}}],\"listeners\":{}}"
+            }
+        },
+        {
+            "id": "remo_activities_initiatives_list",
+            "value": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": "{\"index\":\"remo-activities\",\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"filter\":[]}"
+                },
+                "title": "remo_activities_initiatives_list",
+                "uiStateJSON": "{}",
+                "version": 1,
+                "visState": "{\"title\":\"remo_activities_initiatives_list\",\"type\":\"table\",\"params\":{\"perPage\":10,\"showPartialRows\":false,\"showMeticsAtAllLevels\":false},\"aggs\":[{\"id\":\"3\",\"type\":\"cardinality\",\"schema\":\"metric\",\"params\":{\"field\":\"author_uuid\",\"customLabel\":\"People\"}},{\"id\":\"1\",\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"initiative\",\"size\":500,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"Inititative\"}}],\"listeners\":{}}"
             }
         }
     ]

--- a/dashboards/reps_events.json
+++ b/dashboards/reps_events.json
@@ -8,12 +8,12 @@
                 "searchSourceJSON": "{\"filter\":[{\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}}}]}"
             },
             "optionsJSON": "{\"darkTheme\":false}",
-            "panelsJSON": "[{\"col\":10,\"id\":\"remo_events_categories\",\"panelIndex\":7,\"row\":1,\"size_x\":3,\"size_y\":2,\"title\":\"Categories\",\"type\":\"visualization\"},{\"col\":4,\"id\":\"remo_events_evolutionary\",\"panelIndex\":9,\"row\":1,\"size_x\":3,\"size_y\":2,\"title\":\"Events\",\"type\":\"visualization\"},{\"col\":1,\"id\":\"remo_events_main_metrics\",\"panelIndex\":10,\"row\":1,\"size_x\":3,\"size_y\":2,\"title\":\"Summary\",\"type\":\"visualization\"},{\"col\":7,\"id\":\"remo_events_representatives_countries\",\"panelIndex\":11,\"row\":3,\"size_x\":6,\"size_y\":2,\"title\":\"Representatives and Countries\",\"type\":\"visualization\"},{\"col\":7,\"id\":\"remo_events_representatives_summary\",\"panelIndex\":12,\"row\":1,\"size_x\":3,\"size_y\":2,\"title\":\"Representatives\",\"type\":\"visualization\"},{\"col\":1,\"id\":\"remo_events_map\",\"panelIndex\":13,\"row\":3,\"size_x\":6,\"size_y\":6,\"title\":\"Events\",\"type\":\"visualization\"},{\"col\":7,\"id\":\"remo_events_last_events\",\"panelIndex\":14,\"row\":5,\"size_x\":6,\"size_y\":2,\"title\":\"Last Events\",\"type\":\"visualization\"},{\"col\":7,\"id\":\"remo_events_upcoming_events\",\"panelIndex\":15,\"row\":7,\"size_x\":6,\"size_y\":2,\"title\":\"Upcoming Events\",\"type\":\"visualization\"}]",
+            "panelsJSON": "[{\"col\":10,\"id\":\"remo_events_categories\",\"panelIndex\":7,\"row\":1,\"size_x\":3,\"size_y\":2,\"title\":\"Categories\",\"type\":\"visualization\"},{\"col\":4,\"id\":\"remo_events_evolutionary\",\"panelIndex\":9,\"row\":1,\"size_x\":3,\"size_y\":2,\"title\":\"Events\",\"type\":\"visualization\"},{\"col\":1,\"id\":\"remo_events_main_metrics\",\"panelIndex\":10,\"row\":1,\"size_x\":3,\"size_y\":2,\"title\":\"Summary\",\"type\":\"visualization\"},{\"col\":7,\"id\":\"remo_events_representatives_countries\",\"panelIndex\":11,\"row\":3,\"size_x\":6,\"size_y\":2,\"title\":\"Representatives and Countries\",\"type\":\"visualization\"},{\"col\":7,\"id\":\"remo_events_representatives_summary\",\"panelIndex\":12,\"row\":1,\"size_x\":3,\"size_y\":2,\"title\":\"Representatives\",\"type\":\"visualization\"},{\"col\":1,\"id\":\"remo_events_map\",\"panelIndex\":13,\"row\":3,\"size_x\":6,\"size_y\":8,\"title\":\"Events\",\"type\":\"visualization\"},{\"col\":7,\"id\":\"remo_events_last_events\",\"panelIndex\":14,\"row\":5,\"size_x\":6,\"size_y\":2,\"title\":\"Last Events\",\"type\":\"visualization\"},{\"col\":7,\"id\":\"remo_events_upcoming_events\",\"panelIndex\":15,\"row\":7,\"size_x\":6,\"size_y\":2,\"title\":\"Upcoming Events\",\"type\":\"visualization\"},{\"id\":\"remo_events_categories_list\",\"type\":\"visualization\",\"panelIndex\":16,\"size_x\":6,\"size_y\":2,\"col\":7,\"row\":9,\"title\":\"Categories\"}]",
             "timeFrom": "now-2y",
             "timeRestore": true,
             "timeTo": "now",
             "title": "Reps Events",
-            "uiStateJSON": "{\"P-10\":{\"title\":\"Summary\"},\"P-11\":{\"title\":\"Representatives and Countries\"},\"P-12\":{\"title\":\"Representatives\"},\"P-13\":{\"title\":\"Events\"},\"P-14\":{\"title\":\"Last Events\"},\"P-15\":{\"title\":\"Upcoming Events\"},\"P-7\":{\"title\":\"Categories\"},\"P-9\":{\"title\":\"Events\",\"vis\":{\"legendOpen\":false}},\"title\":\"Events\"}",
+            "uiStateJSON": "{\"P-10\":{\"title\":\"Summary\"},\"P-11\":{\"title\":\"Representatives and Countries\"},\"P-12\":{\"title\":\"Representatives\"},\"P-13\":{\"title\":\"Events\"},\"P-14\":{\"title\":\"Last Events\"},\"P-15\":{\"title\":\"Upcoming Events\"},\"P-7\":{\"title\":\"Categories\"},\"P-9\":{\"title\":\"Events\",\"vis\":{\"legendOpen\":false}},\"title\":\"Events\",\"P-16\":{\"title\":\"Categories\"}}",
             "version": 1
         }
     },
@@ -132,6 +132,19 @@
                 "uiStateJSON": "{}",
                 "version": 1,
                 "visState": "{\"title\":\"remo_events_upcoming_events\",\"type\":\"table\",\"params\":{\"perPage\":10,\"showPartialRows\":false,\"showMeticsAtAllLevels\":false},\"aggs\":[{\"id\":\"1\",\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"start_date\",\"customLabel\":\"Start Date\"}},{\"id\":\"2\",\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"title\",\"size\":30,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"Event Title\"}},{\"id\":\"3\",\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"country\",\"size\":0,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"Country\"}},{\"id\":\"4\",\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"owner\",\"size\":0,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"Representative\"}},{\"id\":\"5\",\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"remo_url\",\"size\":0,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"URL\"}}],\"listeners\":{}}"
+            }
+        },
+        {
+            "id": "remo_events_categories_list",
+            "value": {
+                "description": "",
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": "{\"index\":\"remo-events\",\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"filter\":[]}"
+                },
+                "title": "remo_events_categories_list",
+                "uiStateJSON": "{}",
+                "version": 1,
+                "visState": "{\"title\":\"New Visualization\",\"type\":\"table\",\"params\":{\"perPage\":10,\"showPartialRows\":false,\"showMeticsAtAllLevels\":false},\"aggs\":[{\"id\":\"3\",\"type\":\"cardinality\",\"schema\":\"metric\",\"params\":{\"field\":\"author_uuid\",\"customLabel\":\"People\"}},{\"id\":\"1\",\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"categories.name\",\"size\":500,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"Category\"}}],\"listeners\":{}}"
             }
         }
     ]


### PR DESCRIPTION
Pies group values in  'Other' field if there are more buckets than maximum number of slices. Setting this maximum to more than 20 makes the resulting pie confusing when looking at the smaller slices side.  This way, there could be values not available for filtering through those pie charts. 

This commit adds tables (one per each pie chart) at the bottom of the panel displaying all available values for filtering, and also adding the number of people involved.