### PR TITLE
[owlwatch] Return KO in compare_properties when two dictionaries have differences

### DIFF
--- a/src/owlwatch/schema/model.py
+++ b/src/owlwatch/schema/model.py
@@ -113,7 +113,7 @@ class Schema(object):
         """Comapares two schemas.
 
         Returns -- Tuple [Status, message] being Status
-        'OK' or 'ERROR' and message a string with the list
+        'OK' or 'KO' and message a string with the list
         of properties or the error message containing the
         differences found.
         """
@@ -130,7 +130,7 @@ class Schema(object):
             result = ['OK', props_str]
 
         except AssertionError as e:
-            result = ['ERROR', str(e)]
+            result = ['KO', str(e)]
 
         return result
 

--- a/src/owlwatch/test/test_model.py
+++ b/src/owlwatch/test/test_model.py
@@ -205,17 +205,17 @@ class TestPanel(unittest.TestCase):
         es_mapping_mod.get_properties()['fake_prop'] = 0
 
         result = es_mapping.compare_properties(es_mapping_mod)
-        self.assertEqual(result[0], 'ERROR')
+        self.assertEqual(result[0], 'KO')
 
         # Check comparison ESMapping vs IndexPattern
         index_pattern = IndexPattern.from_json(self.__index_pattern_json)
 
         result = es_mapping_mod.compare_properties(index_pattern)
-        self.assertEqual(result[0], 'ERROR')
+        self.assertEqual(result[0], 'KO')
 
         # Check comparison IndexPattern vs ESMapping
         result = index_pattern.compare_properties(es_mapping_mod)
-        self.assertEqual(result[0], 'ERROR')
+        self.assertEqual(result[0], 'KO')
 
     def test_schema_compare_last_item(self):
         """Test comparison between Schema properties using its


### PR DESCRIPTION
Right now it is not always an error.