### PR TITLE
Fix broken outdated test

### DIFF
--- a/src/owlwatch/test/test_model.py
+++ b/src/owlwatch/test/test_model.py
@@ -268,6 +268,8 @@ class TestPanel(unittest.TestCase):
         """Test comparison between Schema properties using its
         compare method with the last item different (but the same fields) """
 
+        expected_status = 'OK'
+
         mapping_json = None
         panel_json = None
 
@@ -284,12 +286,12 @@ class TestPanel(unittest.TestCase):
                                          mapping_json=mapping_json)
         panel = Panel.from_json(panel_json)
 
-        result = es_mapping.compare_properties(panel.get_index_pattern('git'))
+        result = panel.get_index_pattern('git').compare_properties(es_mapping)
 
-        if result[0] != 'OK':
-            print(result[1])
+        if result['status'] != expected_status:
+            print(result)
 
-        self.assertEqual(result[0], 'OK')
+        self.assertEqual(result['status'], expected_status)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Last test was broken because it used the old compare method output
format for asserts and also didn't take into account comparison
order. So it was not a problem of the test, it was just outdated.