### PR TITLE
[tests] Remove from test checking the ocean-unique-id field

### DIFF
--- a/src/owlwatch/schema/model.py
+++ b/src/owlwatch/schema/model.py
@@ -62,6 +62,8 @@ class Schema(object):
     __excluded_props += ['is_askbot_comment']
     # Cache from confluence could not include this field
     __excluded_props += ['is_attachment', 'is_comment', 'is_new_page']
+    # Old ocean unique identifier
+    __excluded_props += ['ocean-unique-id']
 
     def __init__(self, schema_name):
         self.schema_name = schema_name


### PR DESCRIPTION
This field is not used anymore in GrimoireELK and it is not
used in the panels. It just exists in the index patterns because
it existed in GrimoireELK enriched indexes.

This field has been removed with the arthur support. Now the unique
id for all items is always uuid, the unique id coming from arthur.